### PR TITLE
feat: allows put tags in the layout head

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -11,9 +11,12 @@ const { title } = Astro.props;
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width" />
+
+		<title>{title}</title>
+		<meta name="description" content="Participa en el Hacktoberfest con la comunidad de midudev" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="generator" content={Astro.generator} />
-		<meta name="description" content="Participa en el Hacktoberfest con la comunidad de midudev" />
+
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:site" content="@midudev" />
 		<meta name="twitter:creator" content="@midudev" />
@@ -27,12 +30,22 @@ const { title } = Astro.props;
 		<meta name="og:site_name" content="Midudev Hacktoberfest 2022" />
 		<meta name="og:type" content="website" />
 
-		<title>{title}</title>
+		<slot name="head" />
 	</head>
+
 	<body>
 		<slot />
 	</body>
+
 </html>
+
+<style is:global>
+	code {
+		font-family: Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono,
+			Bitstream Vera Sans Mono, Courier New, monospace;
+	}
+</style>
+
 <style>
 	:root {
 		--font-size-base: clamp(1rem, 0.34vw + 0.91rem, 1.19rem);
@@ -51,15 +64,5 @@ const { title } = Astro.props;
 	body {
 		background: #170F1E;
 		margin: 0;
-	}
-
-
-</style>
-
-<style is:global>
-
-	code {
-		font-family: Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono,
-			Bitstream Vera Sans Mono, Courier New, monospace;
 	}
 </style>


### PR DESCRIPTION
Es para permitir que se puedan poner tags personalizados en la página.
Básicamente el caso de uso que le vi es si alguien usa vanilla JS y el atributo `is:inline` en el tag `<script>`, lo pone fuera del `<html>` tag, lo cual no debería ser así, los tags `<script>` deberían ir dentro del `<head>`.

La forma de usarlo es la siguiente:

```html
---
import Layout from '@layout'
---

<Layout title="Un título">
  <!-- Se puede hacer de cualquiera de estas 2 formas, pero solo se puede tener 1 slot con el mismo nombre -->
  <Fragment slot="head">
    <script type="module" src="my-functions.js"></script>
    <script type="module" src="my-methods.js"></script>
  </Fragment>

  <script slot="head" type="module" src="my-functions.js"></script>

  <!-- Todo lo que se ponga aquí irá en el lugar que se puso el <slot /> -->
  <h1>Hola mundo</h1>
<Layout>
```