### PR TITLE
fix: improve mobile styles of `entry` page

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -59,7 +59,7 @@ const { title } = Astro.props
 
 			html,
 			body {
-				height: 100%;
+				min-height: 100%;
 			}
 		</style>
 

--- a/src/pages/entry/index.astro
+++ b/src/pages/entry/index.astro
@@ -74,8 +74,8 @@ import Layout from '@layout'
 		}
 	</style>
 
-	<main class='pt-20 p-10'>
-		<section class='container mx-auto text-center px-32'>
+	<main class='w-full pt-20 p-10'>
+		<section class='max-w-5xl mx-auto text-center'>
 			<Participants showAll />
 		</section>
 	</main>


### PR DESCRIPTION
Currently (https://hacktoberfest-2022.vercel.app/entry)
![Screenshot_2022-10-02-16-14-28-203_com android chrome](https://user-images.githubusercontent.com/70046023/193474957-3d71dec5-8c6e-4b34-ab24-c3108d140703.jpg)

After commits
![IMG_20221002_162701](https://user-images.githubusercontent.com/70046023/193474971-c4a7d34f-819f-4804-aecc-da5c4afeac03.jpg)

Also in desktop
![Screenshot_2022-10-02_16-32-54](https://user-images.githubusercontent.com/70046023/193475052-18a93885-368a-47f5-a888-251bcd673228.png)

